### PR TITLE
Add NAMESERVER variable for dig

### DIFF
--- a/cns-hook-util
+++ b/cns-hook-util
@@ -1,5 +1,5 @@
 function getservice {
-	local vmuuid="$(dig +short txt "${domain}" @8.8.8.8 | tail -1 | sed 's/"//g')"
+	local vmuuid="$(dig +short txt "${domain}" @${NAMESERVER:-8.8.8.8} | tail -1 | sed 's/"//g')"
 	if [ "a$vmuuid" == "a" ]; then
 		echo "ERROR: ${domain} does not appear to be a CNS name or CNAME to a CNS name" >&2
 		exit 1
@@ -27,14 +27,14 @@ function getservice {
 function verifyvm {
 	local domain="${1}" vmuuid="${2}"
 
-	if ! dig +short txt "${domain}" @8.8.8.8 | sed 's/"//g' | grep -w -- "${vmuuid}" >/dev/null; then
+	if ! dig +short txt "${domain}" @${NAMESERVER:-8.8.8.8} | sed 's/"//g' | grep -w -- "${vmuuid}" >/dev/null; then
 		echo "ERROR: ${domain} does not appear to be a CNS name or CNAME to a CNS name for VM ${vmuuid}" >&2
 		exit 1
 	fi
 
-	local cname="$(dig +short cname "${domain}" @8.8.8.8)"
+	local cname="$(dig +short cname "${domain}" @${NAMESERVER:-8.8.8.8})"
 	if [ "a$cname" != "a" ]; then
-		local acmecname="$(dig +short cname "_acme-challenge.${domain}" @8.8.8.8)"
+		local acmecname="$(dig +short cname "_acme-challenge.${domain}" @${NAMESERVER:-8.8.8.8})"
 		if [ "a$acmecname" == "a" ]; then
 			echo "ERROR: ${domain} is a CNAME to ${cname}, but _acme-challenge.${domain} is not a CNAME" >&2
 			exit 1
@@ -49,8 +49,8 @@ function waitfortxt {
         read -r -a values <<< "$txtval"
         for val in "${values[@]}"; do
                 while [ $count -lt 3 ]; do
-                        dig +short txt "_acme-challenge.${domain}" @8.8.8.8
-                        if dig +short txt "_acme-challenge.${domain}" @8.8.8.8 | grep -w "$val" >/dev/null; then
+                        dig +short txt "_acme-challenge.${domain}" @${NAMESERVER:-8.8.8.8}
+                        if dig +short txt "_acme-challenge.${domain}" @${NAMESERVER:-8.8.8.8} | grep -w "$val" >/dev/null; then
                                 count=$(($count + 1))
                         else
                                 count=0

--- a/config
+++ b/config
@@ -15,6 +15,9 @@
 # default: <unset>
 #IP_VERSION=
 
+# Proxy server to use for letsencrypt.org APIs
+#CURL_OPTS="-x http://proxy:3128"
+
 # Path to certificate authority (default: https://acme-v02.api.letsencrypt.org/directory)
 #CA="https://acme-v02.api.letsencrypt.org/directory"
 #CA="https://acme-staging-v02.api.letsencrypt.org/directory"
@@ -88,6 +91,6 @@ KEY_ALGO=rsa
 # Option to add CSR-flag indicating OCSP stapling to be mandatory (default: no)
 #OCSP_MUST_STAPLE="no"
 
-if [[ -f config.overrides ]]; then
-    source config.overrides
+if [[ -f $SCRIPTDIR/config.overrides ]]; then
+    source $SCRIPTDIR/config.overrides
 fi

--- a/config
+++ b/config
@@ -15,9 +15,6 @@
 # default: <unset>
 #IP_VERSION=
 
-# Proxy server to use for letsencrypt.org APIs
-#CURL_OPTS="-x http://proxy:3128"
-
 # Path to certificate authority (default: https://acme-v02.api.letsencrypt.org/directory)
 #CA="https://acme-v02.api.letsencrypt.org/directory"
 #CA="https://acme-staging-v02.api.letsencrypt.org/directory"
@@ -91,6 +88,6 @@ KEY_ALGO=rsa
 # Option to add CSR-flag indicating OCSP stapling to be mandatory (default: no)
 #OCSP_MUST_STAPLE="no"
 
-if [[ -f $SCRIPTDIR/config.overrides ]]; then
-    source $SCRIPTDIR/config.overrides
+if [[ -f config.overrides ]]; then
+    source config.overrides
 fi


### PR DESCRIPTION
This enables `$NAMESERVER` env variable for dig. Useful for cases where DNS is not allowed directly to 8.8.8.8.