### PR TITLE
change get_zonename

### DIFF
--- a/cns-hook-util
+++ b/cns-hook-util
@@ -108,9 +108,10 @@ function mdata_delete {
 }
 
 function get_zonename {
-    local cmd=$(find_path /usr/bin/zonename)
-    $cmd
+    local cmd=$(mdata_get sdc:uuid)
+        echo $cmd
 }
+
 
 function merge_token {
 	local domain="${1}" tokenval="${2}"


### PR DESCRIPTION
Changed get_zonename to use mdata. because mdata does also know the UUID and not all (custom) images does have the zonename command.