### PR TITLE
Bump dehydrated version to v0.7.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/dehydrated"]
 	path = deps/dehydrated
-	url = https://github.com/lukas2511/dehydrated
+	url = https://github.com/dehydrated-io/dehydrated

--- a/README.md
+++ b/README.md
@@ -39,16 +39,10 @@ certificates automatically for Triton, using DNS challenges. Requires CNS.
 
     List on each line the DNS name you've chosen to use for that service (e.g.
     `cloudapi.dc1.cns.example.com` or `dc1.api.example.com`)
- 6. Set up your **Let's Encrypt** account keys by running:
+ 6. Now get your first set of RSA certificates.
 
     ```shell
-    /opt/dehydrated/dehydrated --register --accept-terms
-    ```
-
- 7. Now get your first set of RSA certificates.
-
-    ```shell
-        [root@headnode (emy-15) ~]$ /opt/dehydrated/dehydrated -c
+        [root@headnode (emy-15) ~]$ /opt/dehydrated/dehydrated -c --accept-terms
         # INFO: Using main config file /opt/dehydrated/config
         Processing adminui.emy-15.cns.joyent.us
          + Generating private key...
@@ -100,31 +94,45 @@ should work on LX-branded zones as well.
     deployment (see
     [the CNS operator guide](https://github.com/joyent/triton-cns/blob/master/docs/operator-guide.md)).
     We'll assume for the sake of example here that the CNS suffix for the
-    DC is `us-west-1.triton.zone`.
+    DC is
+    ```
+    us-west-1.triton.zone
+    ```
  2. Find the CNS-generated name for your container. One way to do this is
     to look at the output of `triton inst get <instance>` for the `dns_names`
     array. As an example, let's consider
-    `blog.svc.3c330096-89e6-11e7-9f13-23d71a63353e.us-west-1.triton.zone`.
+    ```
+    blog.svc.3c330096-89e6-11e7-9f13-23d71a63353e.us-west-1.triton.zone
+    ```
  3. Set up your desired DNS name as a CNAME to this CNS-generated name. If you
     are hosting the root of your domain, it's also fine to just set up a
     regular A record instead, as long as you also deploy a TXT record
     containing the full UUID of the container. We'll use `blog.example.com`
     and CNAME it to
-    `blog.svc.3c330096-89e6-11e7-9f13-23d71a63353e.us-west-1.triton.zone`.
+    ```
+    blog.svc.3c330096-89e6-11e7-9f13-23d71a63353e.us-west-1.triton.zone
+    ```
  4. Set up `_acme-challenge.<domain>` as a CNAME to
     `_acme-challenge.<cnsdomain>`. We'll set up
-    `_acme-challenge.blog.example.com` as a CNAME to
-    `_acme-challenge.blog.svc.3c330096-89e6-11e7-9f13-23d71a63353e.us-west-1.triton.zone`.
+    ```
+    _acme-challenge.blog.example.com
+    ```
+    as a CNAME to
+    ```
+    _acme-challenge.blog.svc.3c330096-89e6-11e7-9f13-23d71a63353e.us-west-1.triton.zone
+    ```
  5. Inside the container, download and extract the `dehydrated.tar.gz` file
     from the [latest GitHub release](https://github.com/joyent/triton-dehydrated/releases/)
     into a directory.
  6. Create a new file `domains.txt` in the directory containing just one line
-    with the full domain name you want on the certificate (e.g.
-    `blog.example.com`).
- 7. Register with the **Let's Encrypt** server by running
-    `./dehydrated --register --accept-terms`
- 8. Get the first certificate by running
-    `./dehydrated -c`
+    with the full domain name you want on the certificate, e.g.
+    ```
+    blog.example.com
+    ```
+ 7. Get the first certificate by running
+    ```shell
+    ./dehydrated -c --accept-terms
+    ```
 
 Now you will find your certificate files in `./certs/blog.example.com/`. You
 should configure your webserver to get the private key and certificate file

--- a/README.md
+++ b/README.md
@@ -99,15 +99,21 @@ should work on LX-branded zones as well.
     us-west-1.triton.zone
     ```
  2. Find the CNS-generated name for your container. One way to do this is
-    to look at the output of `triton inst get <instance>` for the `dns_names`
-    array. As an example, let's consider
+    to look for the `dns_names` array in the output of
+    ```shell
+    triton inst get <instance>
+    ```
+    As an example, let's consider
     ```
     blog.svc.3c330096-89e6-11e7-9f13-23d71a63353e.us-west-1.triton.zone
     ```
  3. Set up your desired DNS name as a CNAME to this CNS-generated name. If you
     are hosting the root of your domain, it's also fine to just set up a
     regular A record instead, as long as you also deploy a TXT record
-    containing the full UUID of the container. We'll use `blog.example.com`
+    containing the full UUID of the container. We'll use
+    ```
+    blog.example.com
+    ```
     and CNAME it to
     ```
     blog.svc.3c330096-89e6-11e7-9f13-23d71a63353e.us-west-1.triton.zone

--- a/config
+++ b/config
@@ -119,10 +119,6 @@ KEY_ALGO=rsa
 # OCSP refresh interval (default: 5 days)
 #OCSP_DAYS=5
 
-if [[ -f $SCRIPTDIR/config.overrides ]]; then
-    source $SCRIPTDIR/config.overrides
-fi
-
 # Issuer chain cache directory (default: $BASEDIR/chains)
 #CHAINCACHE="${BASEDIR}/chains"
 
@@ -134,3 +130,7 @@ fi
 
 # Preferred issuer chain (default: <unset> -> uses default chain)
 #PREFERRED_CHAIN=
+
+if [[ -f $SCRIPTDIR/config.overrides ]]; then
+    source $SCRIPTDIR/config.overrides
+fi

--- a/config
+++ b/config
@@ -10,22 +10,30 @@
 # Default values of this config are in comments        #
 ########################################################
 
+# Which user should dehydrated run as? This will be implicitly enforced when running as root
+#DEHYDRATED_USER=
+
+# Which group should dehydrated run as? This will be implicitly enforced when running as root
+#DEHYDRATED_GROUP=
+
 # Resolve names to addresses of IP version only. (curl)
 # supported values: 4, 6
 # default: <unset>
 #IP_VERSION=
 
-# Proxy server to use for letsencrypt.org APIs
-#CURL_OPTS="-x http://proxy:3128"
+# URL to certificate authority or internal preset
+# Presets: letsencrypt, letsencrypt-test, zerossl, buypass, buypass-test
+# default: letsencrypt
+#CA="letsencrypt"
 
-# Path to certificate authority (default: https://acme-v02.api.letsencrypt.org/directory)
-#CA="https://acme-v02.api.letsencrypt.org/directory"
-#CA="https://acme-staging-v02.api.letsencrypt.org/directory"
+# Path to old certificate authority
+# Set this value to your old CA value when upgrading from ACMEv1 to ACMEv2 under a different endpoint.
+# If dehydrated detects an account-key for the old CA it will automatically reuse that key
+# instead of registering a new one.
+# default: https://acme-v01.api.letsencrypt.org/directory
+#OLDCA="https://acme-v01.api.letsencrypt.org/directory"
 
-# Path to license agreement (default: https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf)
-#LICENSE="https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf"
-
-# Which challenge should be used? Currently http-01 and dns-01 are supported
+# Which challenge should be used? Currently http-01, dns-01 and tls-alpn-01 are supported
 CHALLENGETYPE="dns-01"
 
 # Path to a directory containing additional config files, allowing to override
@@ -33,6 +41,11 @@ CHALLENGETYPE="dns-01"
 # in this directory needs to be named with a '.sh' ending.
 # default: <unset>
 #CONFIG_D=
+
+# Directory for per-domain configuration files.
+# If not set, per-domain configurations are sourced from each certificates output directory.
+# default: <unset>
+#DOMAINS_D=
 
 # Base directory for account key, generated certificates and list of domains (default: $SCRIPTDIR -- uses config directory if undefined)
 #BASEDIR=$SCRIPTDIR
@@ -43,6 +56,9 @@ CHALLENGETYPE="dns-01"
 # Output directory for generated certificates
 #CERTDIR="${BASEDIR}/certs"
 
+# Output directory for alpn verification certificates
+#ALPNCERTDIR="${BASEDIR}/alpn-certs"
+
 # Directory for account keys and registration information
 #ACCOUNTDIR="${BASEDIR}/accounts"
 
@@ -50,10 +66,16 @@ CHALLENGETYPE="dns-01"
 #WELLKNOWN="/var/www/dehydrated"
 
 # Default keysize for private keys (default: 4096)
-KEYSIZE="2048"
+#KEYSIZE="4096"
 
 # Path to openssl config file (default: <unset> - tries to figure out system default)
 #OPENSSL_CNF=
+
+# Path to OpenSSL binary (default: "openssl")
+#OPENSSL="openssl"
+
+# Extra options passed to the curl binary (default: <unset>)
+#CURL_OPTS=
 
 # Program or function called in certain situations
 #
@@ -91,6 +113,24 @@ KEY_ALGO=rsa
 # Option to add CSR-flag indicating OCSP stapling to be mandatory (default: no)
 #OCSP_MUST_STAPLE="no"
 
+# Fetch OCSP responses (default: no)
+#OCSP_FETCH="no"
+
+# OCSP refresh interval (default: 5 days)
+#OCSP_DAYS=5
+
 if [[ -f $SCRIPTDIR/config.overrides ]]; then
     source $SCRIPTDIR/config.overrides
 fi
+
+# Issuer chain cache directory (default: $BASEDIR/chains)
+#CHAINCACHE="${BASEDIR}/chains"
+
+# Automatic cleanup (default: no)
+#AUTO_CLEANUP="no"
+
+# ACME API version (default: auto)
+#API=auto
+
+# Preferred issuer chain (default: <unset> -> uses default chain)
+#PREFERRED_CHAIN=

--- a/config
+++ b/config
@@ -75,7 +75,8 @@ CHALLENGETYPE="dns-01"
 #OPENSSL="openssl"
 
 # Extra options passed to the curl binary (default: <unset>)
-#CURL_OPTS=
+# E.g. Proxy server to use for letsencrypt.org APIs
+#CURL_OPTS="-x http://proxy:3128"
 
 # Program or function called in certain situations
 #

--- a/config.ecdsa
+++ b/config.ecdsa
@@ -23,5 +23,5 @@ source ${BASEDIR}/config
 # File containing the list of domains to request ECDSA certificates for
 DOMAINS_TXT="${BASEDIR}/domains.ecdsa.txt"
 
-# Use ECDSA curve prime256v1. You may also choose to use curve secp384r1.
-KEY_ALGO=prime256v1
+# Use ECDSA curve secp384r1. You may also choose to use curve prime256v1.
+KEY_ALGO=secp384r1


### PR DESCRIPTION
Thanks for this nice tool!

- Bumped [dehydrated version to v0.7.0](https://github.com/dehydrated-io/dehydrated/releases/tag/v0.7.0)
- Synced with upstream config example and follow dehydrated defaults (RSA `KEYSIZE="4096"`, ECSDA `KEY_ALGO=secp384r1`)
- did a few changes to the Readme that make the second part easier to read IMO

feedback welcome