### PR TITLE
Fix variable in cns-hook-util

### DIFF
--- a/cns-hook-util
+++ b/cns-hook-util
@@ -230,7 +230,7 @@ function clean_challenge {
     : "$tokenfn" > /dev/null 2>&1
 
     local zname
-    alias=$(get_zonename)
+    zname=$(get_zonename)
     if [ "$zname" != "global" ]; then
         verifyvm "$domain" "$zname"
         mdata_delete "triton.cns.acme-challenge"


### PR DESCRIPTION
Before:
In global zone:
- running `/opt/letsencrypt/dehydrated -c` exits with error:
```
...
clean_challenge
ERROR: cmon.dc-1.example.com does not appear to be a CNS name or CNAME to a CNS name for VM
...
```

After:
Tested with cert renewal of `grafana` instance, `clean_challenge` function confirmed working in global zone.