### PR TITLE
Add patch to replace hexdump with od

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ VERSION=	$(shell git tag --sort=taggerdate | tail -1)
 # Prevent macOS from putting resource forks in the tar
 export COPYFILE_DISABLE=true
 
-.PHONY: archive release subclean
+.PHONY: archive patch release subclean
 archive: $(ARCHIVE)
 
 release: clean .version $(ARCHIVE)
@@ -22,7 +22,7 @@ release: clean .version $(ARCHIVE)
 	echo "$(VERSION)" > $@
 	git rev-parse HEAD 2>/dev/null >> $@
 
-$(ARCHIVE): clean $(SCRIPT) .version
+$(ARCHIVE): clean $(SCRIPT) patch .version
 	find . -type f \
 	    -not -path '*/.git/*' \
 	    -not -name '.git*' \
@@ -33,6 +33,12 @@ $(ARCHIVE): clean $(SCRIPT) .version
 
 $(SCRIPT):
 	git submodule init && git submodule update
+
+# This is a temporary hack to work around an upstream bug. We want a better
+# way to handle this.
+# https://github.com/dehydrated-io/dehydrated/issues/910
+patch: $(SCRIPT)
+	patch -p1 $< < PATCHES/000-fix-hexdump-check.patch
 
 subclean:
 	git submodule foreach --recursive git reset --hard

--- a/PATCHES/000-fix-hexdump-check.patch
+++ b/PATCHES/000-fix-hexdump-check.patch
@@ -1,0 +1,31 @@
+From 2140d744dc582a438a0ca56c64e022103ae975f5 Mon Sep 17 00:00:00 2001
+From: Brianna Bennett <bahamat@digitalelf.net>
+Date: Tue, 6 Aug 2024 13:47:45 -0700
+Subject: [PATCH] dehydrated#910 hexdump not always available
+
+---
+ dehydrated | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/dehydrated b/dehydrated
+index a15fb048..fe9e660d 100755
+--- a/dehydrated
++++ b/dehydrated
+@@ -260,7 +260,7 @@ _mktemp() {
+ # Check for script dependencies
+ check_dependencies() {
+   # look for required binaries
+-  for binary in grep mktemp diff sed awk curl cut head tail hexdump; do
++  for binary in grep mktemp diff sed awk curl cut head tail od; do
+     bin_path="$(command -v "${binary}" 2>/dev/null)" || _exiterr "This script requires ${binary}."
+     [[ -x "${bin_path}" ]] || _exiterr "${binary} found in PATH but it's not executable"
+   done
+@@ -839,7 +839,7 @@ hex2bin() {
+ 
+ # Convert binary data to hex string
+ bin2hex() {
+-  hexdump -v -e '/1 "%02x"'
++  od -t xC -An | tr -d '[:space:]'
+ }
+ 
+ # OpenSSL writes to stderr/stdout even when there are no errors. So just


### PR DESCRIPTION
The `hexdump` binary is only required when using ZeroSSL as CA. This patch moves the check to the according function, unbreaking the script for Let's Encrypt CA.

Fixes #65. Tested script works on SmartOS with this change and Let's Encrypt as CA.